### PR TITLE
Update JOI.how.mdx to include fork link, #24

### DIFF
--- a/docs/tools-list/media/JOI.how.mdx
+++ b/docs/tools-list/media/JOI.how.mdx
@@ -13,6 +13,10 @@ import Compatibility from "@site/src/components/Compatibility"
   - Supports walltaker import, let others choose the porn for your session!
   - Web based, works on anything with a web browser.
 
+> Fork: joi.clynamic.net
+
+[https://joi.clynamic.net/](https://joi.clynamic.net/) is an actively-maintained fork of JOI.how.
+
 ## Compatibility
 
 <Compatibility web />


### PR DESCRIPTION
Includes fork link of actively maintained version of the site (confirmed that JOI.how is still available and so both are going to be linked)